### PR TITLE
fix: resolve #100 — Chinese in timeline

### DIFF
--- a/src/components/data/timelineItem.astro
+++ b/src/components/data/timelineItem.astro
@@ -105,7 +105,7 @@ const getLinkIcon = (type: string) => {
 // 格式化日期
 const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    const locale = langToLocaleMap[getDefaultLanguage()] || "en-US";
+    const locale = "en-US";
     return date.toLocaleDateString(locale, { year: "numeric", month: "long" });
 };
 


### PR DESCRIPTION
## Summary

fix: resolve #100 — Chinese in timeline

## Problem

**Severity**: `Medium` | **File**: `src/components/data/timelineItem.astro`

The timeline component currently displays dates using Chinese locale, showing characters for "year" (年) and "month" (月). This update replaces the locale-specific formatting with an English representation: full month name followed by numeric year (e.g., "January 2026"). The change ensures consistent English output per the issue requirement.

## Solution

Locate the date rendering code inside `timelineItem.astro`. Assuming the component receives a `date` prop (string or Date object), replace the existing formatting logic with:

## Changes

- `src/components/data/timelineItem.astro` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"